### PR TITLE
Remove deprecated offset access

### DIFF
--- a/src/Transport/TCurlClient.php
+++ b/src/Transport/TCurlClient.php
@@ -99,7 +99,7 @@ class TCurlClient extends TTransport
      */
     public function __construct($host, $port = 80, $uri = '', $scheme = 'http')
     {
-        if ((TStringFuncFactory::create()->strlen($uri) > 0) && ($uri{0} != '/')) {
+        if ((TStringFuncFactory::create()->strlen($uri) > 0) && ($uri[0] != '/')) {
             $uri = '/' . $uri;
         }
         $this->scheme_ = $scheme;

--- a/src/Transport/THttpClient.php
+++ b/src/Transport/THttpClient.php
@@ -106,7 +106,7 @@ class THttpClient extends TTransport
      */
     public function __construct($host, $port = 80, $uri = '', $scheme = 'http', array $context = array())
     {
-        if ((TStringFuncFactory::create()->strlen($uri) > 0) && ($uri{0} != '/')) {
+        if ((TStringFuncFactory::create()->strlen($uri) > 0) && ($uri[0] != '/')) {
             $uri = '/' . $uri;
         }
         $this->scheme_ = $scheme;


### PR DESCRIPTION
Improves PHP 7.4 compatibility due to curly brace syntax for accessing array elements and string offsets been deprecated.